### PR TITLE
Upgrade to 0.24.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ The typical use case for this plugin is a regulatory requirement for a bunch
 of fixed [VAT](https://en.wikipedia.org/wiki/Value-added_tax) rates that can
 change once in a while.
 
+0.24.x Upgrade Notes
+-------
+As of KB version `0.24.15`, the plugin requires the following property in order for tax items to be created:
+
+````
+org.killbill.osgi.system.bundle.export.packages.extra=org.killbill.commons.utils.io
+````
+
+We may be able to get rid of this property if future KB versions export this package by default.
+
+
 Quick start
 -----------
 
@@ -108,10 +119,10 @@ codes of the example configuration shall only apply to accounts that have
 “taxCountry” other than “FR” will not be elligible to any of these French tax
 codes in their invoices.
 
-So, the current implementeation of territorial restriction has several
+So, the current implementation of territorial restriction has several
 limitations.
 
-1. There is no support for retricting tax codes to territories that are
+1. There is no support for restricting tax codes to territories that are
    subdivisions of countries. The only subdivision available is: country.
 
 2. The country of tax codes must match the tax country of customer accounts.

--- a/README.md
+++ b/README.md
@@ -21,17 +21,6 @@ The typical use case for this plugin is a regulatory requirement for a bunch
 of fixed [VAT](https://en.wikipedia.org/wiki/Value-added_tax) rates that can
 change once in a while.
 
-0.24.x Upgrade Notes
--------
-As of KB version `0.24.15`, the plugin requires the following property in order for tax items to be created:
-
-````
-org.killbill.osgi.system.bundle.export.packages.extra=org.killbill.commons.utils.io
-````
-
-We may be able to get rid of this property if future KB versions export this package by default.
-
-
 Quick start
 -----------
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-utils</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.77</version>
+        <version>0.146.63</version>
     </parent>
 
     <groupId>org.kill-bill.billing.plugin.java</groupId>
@@ -99,8 +99,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-api</artifactId>
             <scope>provided</scope>
@@ -169,6 +174,11 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-clock</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-utils</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/org/killbill/billing/plugin/simpletax/SimpleTaxPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/simpletax/SimpleTaxPlugin.java
@@ -275,7 +275,7 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
      * @return An immutable holder for helpful pre-computed data when adding or
      *         adjusting taxes in the account invoices. Never {@code null}.
      */
-    private TaxComputationContext createTaxComputationContext(Invoice newInvoice, InvoiceContext invCtx) { //TODO_TS_218 - change this to InvoiceContext?
+    private TaxComputationContext createTaxComputationContext(Invoice newInvoice, InvoiceContext invCtx) {
 
         SimpleTaxConfig cfg = configHandler.getConfigurable(invCtx.getTenantId());
 

--- a/src/main/java/org/killbill/billing/plugin/simpletax/SimpleTaxPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/simpletax/SimpleTaxPlugin.java
@@ -16,39 +16,15 @@
  */
 package org.killbill.billing.plugin.simpletax;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableSetMultimap.builder;
-import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Iterables.transform;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
-import static com.google.common.collect.Ordering.natural;
-import static java.math.BigDecimal.ZERO;
-import static java.math.RoundingMode.HALF_UP;
-import static org.killbill.billing.ObjectType.INVOICE;
-import static org.killbill.billing.ObjectType.INVOICE_ITEM;
-import static org.killbill.billing.notification.plugin.api.ExtBusEventType.INVOICE_CREATION;
-import static org.killbill.billing.plugin.api.invoice.PluginInvoiceItem.createAdjustmentItem;
-import static org.killbill.billing.plugin.api.invoice.PluginInvoiceItem.createTaxItem;
-import static org.killbill.billing.plugin.simpletax.config.SimpleTaxConfig.DEFAULT_TAX_ITEM_DESC;
-import static org.killbill.billing.plugin.simpletax.config.http.CustomFieldService.TAX_COUNTRY_CUSTOM_FIELD_NAME;
-import static org.killbill.billing.plugin.simpletax.internal.TaxCodeService.TAX_CODES_FIELD_NAME;
-import static org.killbill.billing.plugin.simpletax.plumbing.SimpleTaxActivator.PLUGIN_NAME;
-import static org.killbill.billing.plugin.simpletax.util.InvoiceHelpers.amountWithAdjustments;
-import static org.killbill.billing.plugin.simpletax.util.InvoiceHelpers.sumAmounts;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.SetMultimap;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
@@ -58,11 +34,18 @@ import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.invoice.plugin.api.AdditionalItemsResult;
+import org.killbill.billing.invoice.plugin.api.InvoiceContext;
+import org.killbill.billing.invoice.plugin.api.boilerplate.plugin.InvoiceContextImp;
 import org.killbill.billing.notification.plugin.api.ExtBusEvent;
+import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillClock;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillEventDispatcher.OSGIKillbillEventHandler;
+import org.killbill.billing.osgi.libs.killbill.OSGIServiceNotAvailable;
 import org.killbill.billing.payment.api.PluginProperty;
-import org.killbill.billing.plugin.api.PluginCallContext;
 import org.killbill.billing.plugin.api.PluginTenantContext;
+import org.killbill.billing.plugin.api.invoice.PluginAdditionalItemsResult;
 import org.killbill.billing.plugin.api.invoice.PluginInvoicePluginApi;
 import org.killbill.billing.plugin.simpletax.config.SimpleTaxConfig;
 import org.killbill.billing.plugin.simpletax.config.http.CustomFieldService;
@@ -80,23 +63,39 @@ import org.killbill.billing.util.api.CustomFieldUserApi;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.customfield.CustomField;
-import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillEventDispatcher.OSGIKillbillEventHandler;
-import org.killbill.billing.osgi.libs.killbill.OSGIServiceNotAvailable;
-
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.SetMultimap;
-import org.killbill.clock.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSetMultimap.builder;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Ordering.natural;
+import static java.math.BigDecimal.ZERO;
+import static java.math.RoundingMode.HALF_UP;
+import static org.killbill.billing.ObjectType.INVOICE;
+import static org.killbill.billing.ObjectType.INVOICE_ITEM;
+import static org.killbill.billing.notification.plugin.api.ExtBusEventType.INVOICE_CREATION;
+import static org.killbill.billing.plugin.api.invoice.PluginInvoiceItem.createAdjustmentItem;
+import static org.killbill.billing.plugin.api.invoice.PluginInvoiceItem.createTaxItem;
+import static org.killbill.billing.plugin.simpletax.config.SimpleTaxConfig.DEFAULT_TAX_ITEM_DESC;
+import static org.killbill.billing.plugin.simpletax.config.http.CustomFieldService.TAX_COUNTRY_CUSTOM_FIELD_NAME;
+import static org.killbill.billing.plugin.simpletax.internal.TaxCodeService.TAX_CODES_FIELD_NAME;
+import static org.killbill.billing.plugin.simpletax.util.InvoiceHelpers.amountWithAdjustments;
+import static org.killbill.billing.plugin.simpletax.util.InvoiceHelpers.sumAmounts;
 
 /**
  * Main class for the Kill Bill Simple Tax Plugin.
@@ -153,7 +152,7 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
     }
 
     public SimpleTaxPlugin(SimpleTaxConfigurationHandler configHandler, CustomFieldService customFieldService,
-            OSGIKillbillAPI metaApi, OSGIConfigPropertiesService configService,
+                           OSGIKillbillAPI metaApi, OSGIConfigPropertiesService configService,
                            OSGIKillbillClock clockService) {
         this(configHandler, customFieldService, metaApi, configService, clockService, LoggerFactory.getLogger(SimpleTaxPlugin.class));
     }
@@ -188,18 +187,18 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
      *                   <a href=
      *                   "http://docs.killbill.io/0.15/userguide_payment.html#_plugin_properties"
      *                   >documentation for payment plugins</a>.
-     * @param callCtx    The context in which this code is running.
+     * @param invCtx    The context in which this code is running.
      * @return A new immutable list of new tax items, or adjustments on existing
      * tax items. Never {@code null}, and guaranteed not having any
      * {@code null} elements.
      */
     @Override
-    public List<InvoiceItem> getAdditionalInvoiceItems(Invoice newInvoice, boolean dryRun, Iterable<PluginProperty> properties,
-                                                       CallContext callCtx) {
+    public AdditionalItemsResult getAdditionalInvoiceItems(final Invoice newInvoice, final boolean dryRun, Iterable<PluginProperty> properties,
+                                                           final InvoiceContext invCtx) {
 
-        TaxComputationContext taxCtx = createTaxComputationContext(newInvoice, callCtx);
+        TaxComputationContext taxCtx = createTaxComputationContext(newInvoice, invCtx);
         TaxResolver taxResolver = instanciateTaxResolver(taxCtx);
-        Map<UUID, TaxCode> newTaxCodes = addMissingTaxCodes(newInvoice, taxResolver, taxCtx, callCtx);
+        Map<UUID, TaxCode> newTaxCodes = addMissingTaxCodes(newInvoice, taxResolver, taxCtx, invCtx);
 
         ImmutableList.Builder<InvoiceItem> additionalItems = ImmutableList.builder();
         for (Invoice invoice : taxCtx.getAllInvoices()) {
@@ -212,7 +211,8 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
             }
             additionalItems.addAll(newItems);
         }
-        return additionalItems.build();
+        AdditionalItemsResult additionalItemsResult = new PluginAdditionalItemsResult(additionalItems.build(), null);
+        return additionalItemsResult;
     }
 
     @Override
@@ -246,11 +246,11 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
                     exc);
         }
 
-        CallContext callCtx = new PluginCallContext(PLUGIN_NAME, DateTime.now(), null, tenantId);
+        InvoiceContext invCtx = new InvoiceContextImp.Builder<>().withAccountId(null).withTenantId(tenantId).withCreatedDate(DateTime.now()).withInvoice(newInvoice).build();
 
-        TaxComputationContext taxCtx = createTaxComputationContext(newInvoice, callCtx);
+        TaxComputationContext taxCtx = createTaxComputationContext(newInvoice, invCtx);
         TaxResolver taxResolver = instanciateTaxResolver(taxCtx);
-        Map<UUID, TaxCode> newTaxCodes = addMissingTaxCodes(newInvoice, taxResolver, taxCtx, callCtx);
+        Map<UUID, TaxCode> newTaxCodes = addMissingTaxCodes(newInvoice, taxResolver, taxCtx, invCtx);
 
         // Since we're coming from the bus, we need to log-in manually
         // TODO The plugin should have its own table instead of relying on custom fields for this
@@ -260,7 +260,7 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
             UUID invoiceItemId = entry.getKey();
             TaxCode taxCode = entry.getValue();
             // Need to do it by listening to the event since we cannot add custom fields until the invoice is created
-            persistTaxCode(taxCode, invoiceItemId, newInvoice, callCtx);
+            persistTaxCode(taxCode, invoiceItemId, newInvoice, invCtx);
         }
     }
 
@@ -270,19 +270,19 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
      *
      * @param newInvoice
      *            The invoice that is being created.
-     * @param tenantCtx
+     * @param invCtx
      *            The context in which this code is running.
      * @return An immutable holder for helpful pre-computed data when adding or
      *         adjusting taxes in the account invoices. Never {@code null}.
      */
-    private TaxComputationContext createTaxComputationContext(Invoice newInvoice, TenantContext tenantCtx) {
+    private TaxComputationContext createTaxComputationContext(Invoice newInvoice, InvoiceContext invCtx) { //TODO_TS_218 - change this to InvoiceContext?
 
-        SimpleTaxConfig cfg = configHandler.getConfigurable(tenantCtx.getTenantId());
+        SimpleTaxConfig cfg = configHandler.getConfigurable(invCtx.getTenantId());
 
         UUID accountId = newInvoice.getAccountId();
-        Account account = getAccount(accountId, tenantCtx);
+        Account account = getAccount(accountId, invCtx);
         CustomField taxCountryField = customFieldService.findFieldByNameAndAccountAndTenant(
-                TAX_COUNTRY_CUSTOM_FIELD_NAME, accountId, tenantCtx);
+                TAX_COUNTRY_CUSTOM_FIELD_NAME, accountId, invCtx);
         Country accountTaxCountry = null;
         if (taxCountryField != null) {
             try {
@@ -293,12 +293,12 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
             }
         }
 
-        Set<Invoice> allInvoices = allInvoicesOfAccount(account, newInvoice, tenantCtx);
+        Set<Invoice> allInvoices = allInvoicesOfAccount(account, newInvoice, invCtx);
 
         Function<InvoiceItem, BigDecimal> toAdjustedAmount = toAdjustedAmount(allInvoices);
         Ordering<InvoiceItem> byAdjustedAmount = natural().onResultOf(toAdjustedAmount);
 
-        TaxCodeService taxCodeService = taxCodeService(account, allInvoices, cfg, tenantCtx);
+        TaxCodeService taxCodeService = taxCodeService(account, allInvoices, cfg, invCtx);
 
         return new TaxComputationContext(cfg, account, accountTaxCountry, allInvoices, toAdjustedAmount,
                 byAdjustedAmount, taxCodeService);
@@ -318,15 +318,15 @@ public class SimpleTaxPlugin extends PluginInvoicePluginApi implements OSGIKillb
      * @param newInvoice
      *            The new invoice that is being created, which might have
      *            already been saved or not.
-     * @param tenantCtx
+     * @param invCtx
      *            The context in which this code is running.
      * @return A new immutable set of all invoices for the account, including
      *         the new one being created. Never {@code null}, and guaranteed not
      *         having any {@code null} elements.
      */
-    private Set<Invoice> allInvoicesOfAccount(Account account, Invoice newInvoice, TenantContext tenantCtx) {
+    private Set<Invoice> allInvoicesOfAccount(Account account, Invoice newInvoice, InvoiceContext invCtx) {
         ImmutableSet.Builder<Invoice> builder = ImmutableSet.builder();
-        builder.addAll(getInvoicesByAccountId(account.getId(), tenantCtx));
+        builder.addAll(getInvoicesByAccountId(account.getId(), invCtx));
 
         // Workaround for https://github.com/killbill/killbill/issues/265
         builder.add(newInvoice);

--- a/src/main/java/org/killbill/billing/plugin/simpletax/config/http/SimpleTaxServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/simpletax/config/http/SimpleTaxServlet.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.jooby.mvc.Path;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.plugin.core.PluginServlet;
 import org.killbill.billing.plugin.simpletax.config.http.TaxCodeController.TaxCodesPOSTRsc;
@@ -87,6 +88,7 @@ import static org.killbill.billing.plugin.simpletax.plumbing.SimpleTaxActivator.
  *
  * @author Benjamin Gandon
  */
+@Path("/")
 public class SimpleTaxServlet extends PluginServlet {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Ported the plugin to KB `0.24.x`. Some notes:

- I did a round of testing, and tax items are generated as expected
- The `org.killbill.osgi.system.bundle.export.packages.extra=org.killbill.commons.utils.io` property is required for the plugin to work. I will open a `killbill-platform` PR to export this property by default. Once we release a new KB version with this change, this property can be skipped
- The [TestSimpleTaxActivator](https://github.com/pierre/killbill-simple-tax-plugin/blob/master/src/test/java/org/killbill/billing/plugin/simpletax/plumbing/TestSimpleTaxActivator.java) and [TestSimpleTaxServlet](https://github.com/pierre/killbill-simple-tax-plugin/blob/master/src/test/java/org/killbill/billing/plugin/simpletax/config/http/TestSimpleTaxServlet.java) fail currently due to `NoClassDefFoundErrors` related to the `org.killbill.commons.utils.io` package. Locally, I made changes to `killbill-platform` to export this package by default and then upgraded the `killbill-oss-parent` version in the plugin pom.  The tests passed with these changes. 